### PR TITLE
Label Handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -618,8 +618,9 @@ func fetchQueueSize(label string) int {
 			check2 := fmt.Sprintf("Waiting for next available executor on '%s'", label)
 			// doesn’t have label skx’
 			check3 := fmt.Sprintf("doesn’t have label ‘%s’", label)
+			check4 := fmt.Sprintf("‘%s’ is offline", label)
 
-			if strings.Contains(i.Why, check) || strings.Contains(i.Why, check2) || strings.Contains(i.Why, check3) {
+			if strings.Contains(i.Why, check) || strings.Contains(i.Why, check2) || strings.Contains(i.Why, check3) || strings.Contains(i.Why, check4) {
 				log.Printf("LOG: Need to allocate a new node of label %s\n", label)
 				counter = counter + 1
 			}

--- a/main.go
+++ b/main.go
@@ -621,10 +621,12 @@ func fetchQueueSize(label string) int {
 
 			// Q: what is the i.Why string format?
 
-			if strings.Contains(i.Why, label) && (strings.Contains(i.Why, check2) || strings.Contains(i.Why, check) || strings.Contains(i.Why, check3)) {
+			// check if i.Why contains check, check2 or check3
+			if strings.Contains(i.Why, check) || strings.Contains(i.Why, check2) || strings.Contains(i.Why, check3) {
 				log.Printf("LOG: Need to allocate a new node of label %s\n", label)
 				counter = counter + 1
 			}
+
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -614,12 +614,15 @@ func fetchQueueSize(label string) int {
 		if i.Buildable && !strings.HasPrefix(i.Why, "there are no nodes with the label") {
 			log.Printf("Job's Why statement (api/json): %s\n", i.Why)
 
-			// create a string called "check" that is `label` + `is offline` but add quotes around the label so that it can be used in the strings.Contains function
-			check := fmt.Sprintf("\"%s\" is offline", label)
-			check2 := fmt.Sprintf("All nodes of label \"'%s'\" are offline", label)
+			// check := fmt.Sprintf("\"%s\" is offline", label)
+			check := fmt.Sprintf("All nodes of label \"'%s'\" are offline", label)
+			check2 := fmt.Sprintf("Waiting for next available executor on '%s'", label)
+			check3 := fmt.Sprintf("doesn't have label '%s'", label)
 
-			if strings.Contains(i.Why, label) && (strings.Contains(i.Why, check2) || strings.Contains(i.Why, check)) {
-				log.Printf("LOG: Need to allocate a new node of label ")
+			// Q: what is the i.Why string format?
+
+			if strings.Contains(i.Why, label) && (strings.Contains(i.Why, check2) || strings.Contains(i.Why, check) || strings.Contains(i.Why, check3)) {
+				log.Printf("LOG: Need to allocate a new node of label %s\n", label)
 				counter = counter + 1
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -614,14 +614,11 @@ func fetchQueueSize(label string) int {
 		if i.Buildable && !strings.HasPrefix(i.Why, "there are no nodes with the label") {
 			log.Printf("Job's Why statement (api/json): %s\n", i.Why)
 
-			// check := fmt.Sprintf("\"%s\" is offline", label)
 			check := fmt.Sprintf("All nodes of label \"'%s'\" are offline", label)
 			check2 := fmt.Sprintf("Waiting for next available executor on '%s'", label)
-			check3 := fmt.Sprintf("doesn’t have label ’%s’", label)
+			// doesn’t have label skx’
+			check3 := fmt.Sprintf("doesn’t have label ‘%s’", label)
 
-			// Q: what is the i.Why string format?
-
-			// check if i.Why contains check, check2 or check3
 			if strings.Contains(i.Why, check) || strings.Contains(i.Why, check2) || strings.Contains(i.Why, check3) {
 				log.Printf("LOG: Need to allocate a new node of label %s\n", label)
 				counter = counter + 1

--- a/main.go
+++ b/main.go
@@ -613,7 +613,13 @@ func fetchQueueSize(label string) int {
 	for _, i := range data.Items {
 		if i.Buildable && !strings.HasPrefix(i.Why, "there are no nodes with the label") {
 			log.Printf("Job's Why statement (api/json): %s\n", i.Why)
-			if strings.Contains(i.Why, label) && (strings.Contains(i.Why, "Waiting for next available executor on") || strings.Contains(i.Why, "All nodes of label") || strings.Contains(i.Why, "is offline")) {
+
+			// create a string called "check" that is `label` + `is offline` but add quotes around the label so that it can be used in the strings.Contains function
+			check := fmt.Sprintf("\"%s\" is offline", label)
+			check2 := fmt.Sprintf("All nodes of label \"'%s'\" are offline", label)
+
+			if strings.Contains(i.Why, label) && (strings.Contains(i.Why, check2) || strings.Contains(i.Why, check)) {
+				log.Printf("LOG: Need to allocate a new node of label ")
 				counter = counter + 1
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -613,7 +613,7 @@ func fetchQueueSize(label string) int {
 	for _, i := range data.Items {
 		if i.Buildable && !strings.HasPrefix(i.Why, "there are no nodes with the label") {
 			log.Printf("Job's Why statement (api/json): %s\n", i.Why)
-			if strings.Contains(i.Why, label) && (strings.Contains(i.Why, "Waiting for next available executor on") || strings.Contains(i.Why, "All nodes of label")) {
+			if strings.Contains(i.Why, label) && (strings.Contains(i.Why, "Waiting for next available executor on") || strings.Contains(i.Why, "All nodes of label") || strings.Contains(i.Why, "is offline")) {
 				counter = counter + 1
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -617,7 +617,7 @@ func fetchQueueSize(label string) int {
 			// check := fmt.Sprintf("\"%s\" is offline", label)
 			check := fmt.Sprintf("All nodes of label \"'%s'\" are offline", label)
 			check2 := fmt.Sprintf("Waiting for next available executor on '%s'", label)
-			check3 := fmt.Sprintf("doesn't have label '%s'", label)
+			check3 := fmt.Sprintf("doesn’t have label ’%s’", label)
 
 			// Q: what is the i.Why string format?
 

--- a/main.go
+++ b/main.go
@@ -158,17 +158,30 @@ func main() {
 }
 
 func generateGCPNodeNames() {
+	/*
+		this function creates a map of build box names to GCP node names
+		format: buildBoxesJenkinsToGCPNameMap["buildBoxName"] = "gcpNodeName"
+
+		It also generates the map of labels to Jenkins build box names
+		in the form: boxLabels["label"] = ["buildBoxName1", "buildBoxName2", ...]
+	*/
 	buildBoxesJenkinsToGCPNameMap = make(map[string]string)
-	var buildBoxWithPrefix strings.Builder
-	for _, buildBox := range buildBoxesPool {
-		if *nodeNamePrefix != "" {
-			buildBoxWithPrefix.WriteString(*nodeNamePrefix)
-		}
-		buildBoxWithPrefix.WriteString(buildBox)
-		buildBoxesJenkinsToGCPNameMap[buildBox] = buildBoxWithPrefix.String()
-		buildBoxWithPrefix.Reset()
+
+	for i := 0; i <= len(buildBoxesPool)-1; i++ {
+		buildBoxesJenkinsToGCPNameMap[buildBoxesPool[i]] = gcpBoxesPool[i]
+	}
+	fmt.Println("jenkins boxes: ", buildBoxesPool)
+	fmt.Println("gcp boxes: ", gcpBoxesPool)
+	fmt.Println("box labels: ", boxLabels)
+
+	buildBoxesLabelToJenkinsNameMap = make(map[string][]string)
+	for i := 0; i <= len(boxLabels)-1; i++ {
+		buildBoxesLabelToJenkinsNameMap[boxLabels[i]] = append(buildBoxesLabelToJenkinsNameMap[boxLabels[i]], buildBoxesPool[i])
+		// fmt.Println(buildBoxesLabelToJenkinsNameMap)
+
 	}
 }
+
 func validateFlags() {
 	valid := true
 	if *gceProjectName == "" {


### PR DESCRIPTION
1. Node names and GCP hostnames are now defined in the flags
2. New data structure to handle a mapping from jenkins node names to gcp node names
3. New mapping from label to a pool of boxes 
4. autoscaling() now cycles through every label option. Functionality: if theres jobs in the build queue with that label, switch on extra boxes with that label. If there are no jobs in the build queue with that label, switch off idle boxes